### PR TITLE
svg class customization: fix an issue for string replace

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -58,7 +58,15 @@ function genFullFilePath(base, filename) {
     }
     return path.join(dir, filename);
 }
-
+function svgAddClass(svg_txt, className) {
+    let match = svg_txt.match(/<svg(.*?)>/)
+    if (match && match[1].includes('class')) {
+        return svg_txt.replace(/<svg(.*)class="(.*?)"(.*)>/, `<svg$1class="$2,${className}"$3>`)
+    }
+    else{
+        return svg_txt.replace(/<svg(.*?)>/, `<svg$1 class="${className}">`)
+    }
+}
 /**
  *
  * @param {PluginConfig} pluginConfig the merged config
@@ -83,7 +91,7 @@ function serverSideRendering(pluginConfig, encodedUrl) {
                         } else if (pluginConfig.link === "inlineUrlEncode") {
                             resolve(`<img class="${pluginConfig.className}" src='data:image/svg+xml;utf8,${encodeURIComponent(buffer.toString())}'>`);
                         } else {
-                            resolve(buffer.toString().replace(/<svg(.*?)>/g, `<svg $1 class="${pluginConfig.className}">$2`))
+                            resolve(svgAddClass(buffer.toString(),pluginConfig.className));
                         }
                     });
                 });


### PR DESCRIPTION
There is $2 literally inside the output string, which is fixed by this commit.