### PR TITLE
fix multiple class definition: use space instead of comma.

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -61,7 +61,7 @@ function genFullFilePath(base, filename) {
 function svgAddClass(svg_txt, className) {
     let match = svg_txt.match(/<svg(.*?)>/)
     if (match && match[1].includes('class')) {
-        return svg_txt.replace(/<svg(.*?)class="(.*?)"(.*?)>/, `<svg$1class="$2,${className}"$3>`)
+        return svg_txt.replace(/<svg(.*?)class="(.*?)"(.*?)>/, `<svg$1class="$2 ${className}"$3>`)
     }
     else{
         return svg_txt.replace(/<svg(.*?)>/, `<svg$1 class="${className}">`)


### PR DESCRIPTION
I made a mistake in previous PR  #6 